### PR TITLE
Implemented four classes of game phases with tests

### DIFF
--- a/stone_age/game_phase_controller/game_end_state.py
+++ b/stone_age/game_phase_controller/game_end_state.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
+from stone_age.game_phase_controller.interfaces import GamePhaseStateFailureMeta
 from stone_age.simple_types import PlayerOrder, HasAction
 
 
-class GameEndState(InterfaceGamePhaseState):
+class GameEndState(GamePhaseStateFailureMeta):
     def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
         return HasAction.WAITING_FOR_PLAYER_ACTION
 

--- a/stone_age/game_phase_controller/game_end_state.py
+++ b/stone_age/game_phase_controller/game_end_state.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
+from stone_age.simple_types import PlayerOrder, HasAction
+
+
+class GameEndState(InterfaceGamePhaseState):
+    def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
+        return HasAction.WAITING_FOR_PLAYER_ACTION
+
+    # other actions should not be done in this phase

--- a/stone_age/game_phase_controller/interfaces.py
+++ b/stone_age/game_phase_controller/interfaces.py
@@ -36,3 +36,41 @@ class InterfaceGamePhaseState:
 
     def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
         assert False
+
+
+class GamePhaseStateFailureMeta(InterfaceGamePhaseState):
+    """
+    Created for game phase classes to give them methods returning ActionResult.FAILURE
+    without need to redefine all these methods.
+    """
+
+    def place_figures(self, player: PlayerOrder, location: Location,
+                      figures_count: int) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def make_action(self, player: PlayerOrder, location: Location,
+                    input_resources: Iterable[Effect],
+                    output_resources: Iterable[Effect]) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def skip_action(self, player: PlayerOrder, location: Location) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def use_tools(self, player: PlayerOrder, tool_index: int) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def no_more_tools_this_throw(self, player: PlayerOrder) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def feed_tribe(self, player: PlayerOrder, resources: Iterable[Effect]) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def do_not_feed_this_turn(self, player: PlayerOrder) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def make_all_players_take_a_reward_choice(self, player: PlayerOrder,
+                                              reward: Effect) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
+        assert False

--- a/stone_age/game_phase_controller/make_action_state.py
+++ b/stone_age/game_phase_controller/make_action_state.py
@@ -37,3 +37,24 @@ class MakeActionState(InterfaceGamePhaseState):
             if try_output == HasAction.WAITING_FOR_PLAYER_ACTION:
                 waiting = True
         return HasAction.WAITING_FOR_PLAYER_ACTION if waiting else HasAction.NO_ACTION_POSSIBLE
+
+    # these actions should not be done in this phase
+    def place_figures(self, player: PlayerOrder, location: Location,
+                      figures_count: int) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def use_tools(self, player: PlayerOrder, tool_index: int) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def no_more_tools_this_throw(self, player: PlayerOrder) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def feed_tribe(self, player: PlayerOrder, resources: Iterable[Effect]) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def do_not_feed_this_turn(self, player: PlayerOrder) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def make_all_players_take_a_reward_choice(self, player: PlayerOrder,
+                                              reward: Effect) -> ActionResult:
+        return ActionResult.FAILURE

--- a/stone_age/game_phase_controller/make_action_state.py
+++ b/stone_age/game_phase_controller/make_action_state.py
@@ -39,22 +39,3 @@ class MakeActionState(GamePhaseStateFailureMeta):
         return HasAction.WAITING_FOR_PLAYER_ACTION if waiting else HasAction.NO_ACTION_POSSIBLE
 
     # other actions should not be done in this phase
-    def place_figures(self, player: PlayerOrder, location: Location,
-                      figures_count: int) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def use_tools(self, player: PlayerOrder, tool_index: int) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def no_more_tools_this_throw(self, player: PlayerOrder) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def feed_tribe(self, player: PlayerOrder, resources: Iterable[Effect]) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def do_not_feed_this_turn(self, player: PlayerOrder) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def make_all_players_take_a_reward_choice(self, player: PlayerOrder,
-                                              reward: Effect) -> ActionResult:
-        return ActionResult.FAILURE

--- a/stone_age/game_phase_controller/make_action_state.py
+++ b/stone_age/game_phase_controller/make_action_state.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
+from stone_age.interfaces import InterfaceFigureLocation
+from stone_age.simple_types import PlayerOrder, Location, Effect, ActionResult, HasAction
+
+
+class MakeActionState(InterfaceGamePhaseState):
+    _places: Mapping[Location, InterfaceFigureLocation]
+
+    def __init__(self, places: Mapping[Location, InterfaceFigureLocation]):
+        self._places = places
+
+    def make_action(self, player: PlayerOrder, location: Location,
+                    input_resources: Iterable[Effect],
+                    output_resources: Iterable[Effect]) -> ActionResult:
+        return self._places[location].make_action(player, input_resources, output_resources)
+
+    def skip_action(self, player: PlayerOrder, location: Location) -> ActionResult:
+        """Converts bool output from InterfaceFigureLocation into ActionResult."""
+        if self._places[location].skip_action(player):
+            return ActionResult.ACTION_DONE
+        return ActionResult.FAILURE
+
+    def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
+        """If automatic action can be done, self._places[place].try_to_make_action
+        should do it, otherwise returns whether there are some figures on gameboard
+        waiting for player to make action."""
+        waiting: bool = False
+        for place in self._places:
+            try_output: HasAction = self._places[place].try_to_make_action(
+                player)
+            if try_output == HasAction.AUTOMATIC_ACTION_DONE:
+                return HasAction.AUTOMATIC_ACTION_DONE
+            if try_output == HasAction.WAITING_FOR_PLAYER_ACTION:
+                waiting = True
+        return HasAction.WAITING_FOR_PLAYER_ACTION if waiting else HasAction.NO_ACTION_POSSIBLE

--- a/stone_age/game_phase_controller/make_action_state.py
+++ b/stone_age/game_phase_controller/make_action_state.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Iterable, Mapping
 
-from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
+from stone_age.game_phase_controller.interfaces import GamePhaseStateFailureMeta
 from stone_age.interfaces import InterfaceFigureLocation
 from stone_age.simple_types import PlayerOrder, Location, Effect, ActionResult, HasAction
 
 
-class MakeActionState(InterfaceGamePhaseState):
+class MakeActionState(GamePhaseStateFailureMeta):
     _places: Mapping[Location, InterfaceFigureLocation]
 
     def __init__(self, places: Mapping[Location, InterfaceFigureLocation]):
@@ -26,7 +26,7 @@ class MakeActionState(InterfaceGamePhaseState):
 
     def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
         """If automatic action can be done, self._places[place].try_to_make_action
-        should do it, otherwise returns whether there are some figures on gameboard
+        should do it, otherwise returns whether there are some figures on player board
         waiting for player to make action."""
         waiting: bool = False
         for place in self._places:

--- a/stone_age/game_phase_controller/make_action_state.py
+++ b/stone_age/game_phase_controller/make_action_state.py
@@ -38,23 +38,4 @@ class MakeActionState(InterfaceGamePhaseState):
                 waiting = True
         return HasAction.WAITING_FOR_PLAYER_ACTION if waiting else HasAction.NO_ACTION_POSSIBLE
 
-    # these actions should not be done in this phase
-    def place_figures(self, player: PlayerOrder, location: Location,
-                      figures_count: int) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def use_tools(self, player: PlayerOrder, tool_index: int) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def no_more_tools_this_throw(self, player: PlayerOrder) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def feed_tribe(self, player: PlayerOrder, resources: Iterable[Effect]) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def do_not_feed_this_turn(self, player: PlayerOrder) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def make_all_players_take_a_reward_choice(self, player: PlayerOrder,
-                                              reward: Effect) -> ActionResult:
-        return ActionResult.FAILURE
+    # other actions should not be done in this phase

--- a/stone_age/game_phase_controller/new_round_state.py
+++ b/stone_age/game_phase_controller/new_round_state.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
+from stone_age.interfaces import InterfaceFigureLocation, InterfaceNewTurn
+from stone_age.simple_types import PlayerOrder, Location, HasAction
+
+
+class NewRoundState(InterfaceGamePhaseState):
+    """Uses also Mapping[Location, InterfaceFigureLocation], Iterable of
+    InterfaceFigureLocation in design makes no sense."""
+    _places: Mapping[Location, InterfaceFigureLocation]
+    _new_turn: InterfaceNewTurn
+
+    def __init__(self, places: Mapping[Location, InterfaceFigureLocation],
+                 new_turn: InterfaceNewTurn):
+        self._places = places
+        self._new_turn = new_turn
+
+    def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
+        """NO_ACTION_POSSIBLE in NEW_ROUND game phase triggers GAME_END."""
+        for place in self._places:
+            if self._places[place].new_turn():
+                return HasAction.NO_ACTION_POSSIBLE
+        self._new_turn.new_turn()
+        return HasAction.AUTOMATIC_ACTION_DONE
+
+    # other actions should not be done in this phase

--- a/stone_age/game_phase_controller/new_round_state.py
+++ b/stone_age/game_phase_controller/new_round_state.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Mapping, Iterable
+from typing import Mapping
 
 from stone_age.game_phase_controller.interfaces import GamePhaseStateFailureMeta
 from stone_age.interfaces import InterfaceFigureLocation, InterfaceNewTurn
-from stone_age.simple_types import PlayerOrder, Location, HasAction, ActionResult, Effect
+from stone_age.simple_types import PlayerOrder, Location, HasAction
 
 
 class NewRoundState(GamePhaseStateFailureMeta):
@@ -27,30 +27,3 @@ class NewRoundState(GamePhaseStateFailureMeta):
         return HasAction.AUTOMATIC_ACTION_DONE
 
     # other actions should not be done in this phase
-    def place_figures(self, player: PlayerOrder, location: Location,
-                      figures_count: int) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def make_action(self, player: PlayerOrder, location: Location,
-                    input_resources: Iterable[Effect],
-                    output_resources: Iterable[Effect]) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def skip_action(self, player: PlayerOrder, location: Location) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def use_tools(self, player: PlayerOrder, tool_index: int) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def no_more_tools_this_throw(self, player: PlayerOrder) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def feed_tribe(self, player: PlayerOrder, resources: Iterable[Effect]) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def do_not_feed_this_turn(self, player: PlayerOrder) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def make_all_players_take_a_reward_choice(self, player: PlayerOrder,
-                                              reward: Effect) -> ActionResult:
-        return ActionResult.FAILURE

--- a/stone_age/game_phase_controller/new_round_state.py
+++ b/stone_age/game_phase_controller/new_round_state.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Mapping
 
-from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
+from stone_age.game_phase_controller.interfaces import GamePhaseStateFailureMeta
 from stone_age.interfaces import InterfaceFigureLocation, InterfaceNewTurn
 from stone_age.simple_types import PlayerOrder, Location, HasAction
 
 
-class NewRoundState(InterfaceGamePhaseState):
+class NewRoundState(GamePhaseStateFailureMeta):
     """Uses also Mapping[Location, InterfaceFigureLocation], Iterable of
     InterfaceFigureLocation in design makes no sense."""
     _places: Mapping[Location, InterfaceFigureLocation]
@@ -20,10 +20,10 @@ class NewRoundState(InterfaceGamePhaseState):
 
     def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
         """NO_ACTION_POSSIBLE in NEW_ROUND game phase triggers GAME_END."""
+        self._new_turn.new_turn()
         for place in self._places:
             if self._places[place].new_turn():
                 return HasAction.NO_ACTION_POSSIBLE
-        self._new_turn.new_turn()
         return HasAction.AUTOMATIC_ACTION_DONE
 
     # other actions should not be done in this phase

--- a/stone_age/game_phase_controller/place_figures_state.py
+++ b/stone_age/game_phase_controller/place_figures_state.py
@@ -19,6 +19,7 @@ class PlaceFiguresState(InterfaceGamePhaseState):
 
     def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
         for place in self._places:
-            if self._places[place].try_to_place_figures(player, 1) == HasAction.WAITING_FOR_PLAYER_ACTION:
+            if (self._places[place].try_to_place_figures(player, 1)
+                    == HasAction.WAITING_FOR_PLAYER_ACTION):
                 return HasAction.WAITING_FOR_PLAYER_ACTION
         return HasAction.NO_ACTION_POSSIBLE

--- a/stone_age/game_phase_controller/place_figures_state.py
+++ b/stone_age/game_phase_controller/place_figures_state.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
-from typing import Mapping, Iterable
+from typing import Mapping
 from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
 from stone_age.interfaces import InterfaceFigureLocation
-from stone_age.simple_types import Location, PlayerOrder, ActionResult, HasAction, Effect
+from stone_age.simple_types import Location, PlayerOrder, ActionResult, HasAction
 
 
 class PlaceFiguresState(InterfaceGamePhaseState):
@@ -30,27 +30,4 @@ class PlaceFiguresState(InterfaceGamePhaseState):
                 return HasAction.WAITING_FOR_PLAYER_ACTION
         return HasAction.NO_ACTION_POSSIBLE
 
-    # these actions should not be done in this phase
-    def make_action(self, player: PlayerOrder, location: Location,
-                    input_resources: Iterable[Effect],
-                    output_resources: Iterable[Effect]) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def skip_action(self, player: PlayerOrder, location: Location) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def use_tools(self, player: PlayerOrder, tool_index: int) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def no_more_tools_this_throw(self, player: PlayerOrder) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def feed_tribe(self, player: PlayerOrder, resources: Iterable[Effect]) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def do_not_feed_this_turn(self, player: PlayerOrder) -> ActionResult:
-        return ActionResult.FAILURE
-
-    def make_all_players_take_a_reward_choice(self, player: PlayerOrder,
-                                              reward: Effect) -> ActionResult:
-        return ActionResult.FAILURE
+    # other actions should not be done in this phase

--- a/stone_age/game_phase_controller/place_figures_state.py
+++ b/stone_age/game_phase_controller/place_figures_state.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 from typing import Mapping
-from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
+
+from stone_age.game_phase_controller.interfaces import GamePhaseStateFailureMeta
 from stone_age.interfaces import InterfaceFigureLocation
 from stone_age.simple_types import Location, PlayerOrder, ActionResult, HasAction
 
 
-class PlaceFiguresState(InterfaceGamePhaseState):
+class PlaceFiguresState(GamePhaseStateFailureMeta):
     _places: Mapping[Location, InterfaceFigureLocation]
 
     def __init__(self, places: Mapping[Location, InterfaceFigureLocation]):
@@ -25,8 +27,12 @@ class PlaceFiguresState(InterfaceGamePhaseState):
         doing self._places[place].try_to_place_figures methods for each location).
         """
         for place in self._places:
-            if (self._places[place].try_to_place_figures(player, 1)
-                    == HasAction.WAITING_FOR_PLAYER_ACTION):
+            if place == Location.HUT:
+                if (self._places[place].try_to_place_figures(player, 2)
+                        == HasAction.WAITING_FOR_PLAYER_ACTION):
+                    return HasAction.WAITING_FOR_PLAYER_ACTION
+            elif (self._places[place].try_to_place_figures(player, 1)
+                  == HasAction.WAITING_FOR_PLAYER_ACTION):
                 return HasAction.WAITING_FOR_PLAYER_ACTION
         return HasAction.NO_ACTION_POSSIBLE
 

--- a/stone_age/game_phase_controller/place_figures_state.py
+++ b/stone_age/game_phase_controller/place_figures_state.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from typing import Mapping
+from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
+from stone_age.interfaces import InterfaceFigureLocation
+from stone_age.simple_types import Location, PlayerOrder, ActionResult, HasAction
+
+
+class PlaceFiguresState(InterfaceGamePhaseState):
+    _places: Mapping[Location, InterfaceFigureLocation]
+
+    def __init__(self, places: Mapping[Location, InterfaceFigureLocation]):
+        self._places = places
+
+    def place_figures(self, player: PlayerOrder, location: Location,
+                      figures_count: int) -> ActionResult:
+        if self._places[location].place_figures(player, figures_count):
+            return ActionResult.ACTION_DONE
+        return ActionResult.FAILURE
+
+    def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
+        for place in self._places:
+            if self._places[place].try_to_place_figures(player, 1) == HasAction.WAITING_FOR_PLAYER_ACTION:
+                return HasAction.WAITING_FOR_PLAYER_ACTION
+        return HasAction.NO_ACTION_POSSIBLE

--- a/stone_age/game_phase_controller/place_figures_state.py
+++ b/stone_age/game_phase_controller/place_figures_state.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
-from typing import Mapping
+from typing import Mapping, Iterable
 from stone_age.game_phase_controller.interfaces import InterfaceGamePhaseState
 from stone_age.interfaces import InterfaceFigureLocation
-from stone_age.simple_types import Location, PlayerOrder, ActionResult, HasAction
+from stone_age.simple_types import Location, PlayerOrder, ActionResult, HasAction, Effect
 
 
 class PlaceFiguresState(InterfaceGamePhaseState):
@@ -18,8 +18,39 @@ class PlaceFiguresState(InterfaceGamePhaseState):
         return ActionResult.FAILURE
 
     def try_to_make_automatic_action(self, player: PlayerOrder) -> HasAction:
+        """
+        Automatic placing of figures we do not implement (this could be desirable,
+        if all possible locations are occupied, but it is edge case).
+        Instead, method checks whether player can place any figures (this should be
+        doing self._places[place].try_to_place_figures methods for each location).
+        """
         for place in self._places:
             if (self._places[place].try_to_place_figures(player, 1)
                     == HasAction.WAITING_FOR_PLAYER_ACTION):
                 return HasAction.WAITING_FOR_PLAYER_ACTION
         return HasAction.NO_ACTION_POSSIBLE
+
+    # these actions should not be done in this phase
+    def make_action(self, player: PlayerOrder, location: Location,
+                    input_resources: Iterable[Effect],
+                    output_resources: Iterable[Effect]) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def skip_action(self, player: PlayerOrder, location: Location) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def use_tools(self, player: PlayerOrder, tool_index: int) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def no_more_tools_this_throw(self, player: PlayerOrder) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def feed_tribe(self, player: PlayerOrder, resources: Iterable[Effect]) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def do_not_feed_this_turn(self, player: PlayerOrder) -> ActionResult:
+        return ActionResult.FAILURE
+
+    def make_all_players_take_a_reward_choice(self, player: PlayerOrder,
+                                              reward: Effect) -> ActionResult:
+        return ActionResult.FAILURE

--- a/stone_age/interfaces.py
+++ b/stone_age/interfaces.py
@@ -54,7 +54,8 @@ class InterfaceFigureLocation:
     def make_action(self, player: PlayerOrder, input_resources: Iterable[Effect],
                     output_resources: Iterable[Effect]) -> ActionResult:
         assert isinstance(player, PlayerOrder)
-        assert isinstance(input_resources, Iterable) and isinstance(output_resources, Iterable)
+        assert isinstance(input_resources, Iterable) and isinstance(
+            output_resources, Iterable)
         return ActionResult.FAILURE
 
     def skip_action(self, player: PlayerOrder) -> bool:

--- a/stone_age/interfaces.py
+++ b/stone_age/interfaces.py
@@ -99,3 +99,8 @@ class InterfacePlayerBoardGameBoard:
     def use_tool(self, idx: int) -> Optional[int]:
         assert isinstance(idx, int)
         return 0
+
+
+class InterfaceNewTurn:
+    def new_turn(self) -> None:
+        assert False

--- a/test/game_phase_controller/test_game_end_state.py
+++ b/test/game_phase_controller/test_game_end_state.py
@@ -1,7 +1,7 @@
 import unittest
 
 from stone_age.game_phase_controller.game_end_state import GameEndState
-from stone_age.simple_types import PlayerOrder, HasAction
+from stone_age.simple_types import PlayerOrder, HasAction, ActionResult
 
 
 class TestGameEndState(unittest.TestCase):
@@ -9,5 +9,8 @@ class TestGameEndState(unittest.TestCase):
         player = PlayerOrder(1, 1)
         self.assertEqual(HasAction.WAITING_FOR_PLAYER_ACTION,
                          GameEndState().try_to_make_automatic_action(player))
-        self.assertRaises(
-            AssertionError, GameEndState().do_not_feed_this_turn, player)
+
+    def test_wrong_method_call(self) -> None:
+        player = PlayerOrder(1, 1)
+        self.assertEqual(ActionResult.FAILURE,
+                         GameEndState().do_not_feed_this_turn(player))

--- a/test/game_phase_controller/test_game_end_state.py
+++ b/test/game_phase_controller/test_game_end_state.py
@@ -1,0 +1,13 @@
+import unittest
+
+from stone_age.game_phase_controller.game_end_state import GameEndState
+from stone_age.simple_types import PlayerOrder, HasAction
+
+
+class TestGameEndState(unittest.TestCase):
+    def test_try_automatic_action(self) -> None:
+        player = PlayerOrder(1, 1)
+        self.assertEqual(HasAction.WAITING_FOR_PLAYER_ACTION,
+                         GameEndState().try_to_make_automatic_action(player))
+        self.assertRaises(
+            AssertionError, GameEndState().do_not_feed_this_turn, player)

--- a/test/game_phase_controller/test_make_action_state.py
+++ b/test/game_phase_controller/test_make_action_state.py
@@ -1,0 +1,120 @@
+import unittest
+from typing import Iterable, Mapping
+
+from stone_age.game_phase_controller.make_action_state import MakeActionState
+from stone_age.interfaces import InterfaceFigureLocation
+from stone_age.simple_types import PlayerOrder, HasAction, Effect, ActionResult, Location
+
+
+class LocationMock(InterfaceFigureLocation):
+    _make_response: ActionResult
+    _skip_response: bool
+    _try_response: HasAction
+
+    def __init__(self, make_response: ActionResult = ActionResult.FAILURE,
+                 skip_response: bool = False,
+                 try_response: HasAction = HasAction.NO_ACTION_POSSIBLE):
+        self._make_response = make_response
+        self._skip_response = skip_response
+        self._try_response = try_response
+
+    def place_figures(self, player: PlayerOrder, figure_count: int) -> bool:
+        assert False
+
+    def try_to_place_figures(self, player: PlayerOrder, count: int) -> HasAction:
+        assert False
+
+    def make_action(self, player: PlayerOrder, input_resources: Iterable[Effect],
+                    output_resources: Iterable[Effect]) -> ActionResult:
+        return self._make_response
+
+    def skip_action(self, player: PlayerOrder) -> bool:
+        return self._skip_response
+
+    def try_to_make_action(self, player: PlayerOrder) -> HasAction:
+        return self._try_response
+
+    def new_turn(self) -> bool:
+        assert False
+
+
+class TestMakeActionState(unittest.TestCase):
+    def test_make_action_method(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(ActionResult.ACTION_DONE),
+            Location.FIELD: LocationMock(ActionResult.FAILURE),
+            Location.QUARY: LocationMock(ActionResult.ACTION_DONE_WAIT_FOR_TOOL_USE),
+        }
+        player = PlayerOrder(1, 1)
+        place_figures_state = MakeActionState(places)
+        input_resources: Iterable[Effect] = []
+        output_resources: Iterable[Effect] = []
+        self.assertEqual(ActionResult.ACTION_DONE,
+                         place_figures_state.make_action(player, Location.HUT,
+                                                         input_resources, output_resources))
+        self.assertEqual(ActionResult.FAILURE,
+                         place_figures_state.make_action(player, Location.FIELD,
+                                                         input_resources, output_resources))
+        self.assertEqual(ActionResult.ACTION_DONE_WAIT_FOR_TOOL_USE,
+                         place_figures_state.make_action(player, Location.QUARY,
+                                                         input_resources, output_resources))
+
+    def test_skip_action_method(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(skip_response=True),
+            Location.FIELD: LocationMock(skip_response=False),
+        }
+        player = PlayerOrder(1, 1)
+        make_action_state = MakeActionState(places)
+        self.assertEqual(ActionResult.ACTION_DONE,
+                         make_action_state.skip_action(player, Location.HUT))
+        self.assertEqual(ActionResult.FAILURE,
+                         make_action_state.skip_action(player, Location.FIELD))
+
+    def test_try_automatic_action_all_locations_impossible(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.FIELD: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.QUARY: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+        }
+        player = PlayerOrder(1, 1)
+        make_action_state = MakeActionState(places)
+        self.assertEqual(HasAction.NO_ACTION_POSSIBLE,
+                         make_action_state.try_to_make_automatic_action(player))
+
+    def test_try_automatic_action_one_waiting_location(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.FIELD: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+            Location.QUARY: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+        }
+        player = PlayerOrder(1, 1)
+        make_action_state = MakeActionState(places)
+        self.assertEqual(HasAction.WAITING_FOR_PLAYER_ACTION,
+                         make_action_state.try_to_make_automatic_action(player))
+
+    def test_try_automatic_action_automatic_done(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.FIELD: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.QUARY: LocationMock(try_response=HasAction.AUTOMATIC_ACTION_DONE),
+        }
+        player = PlayerOrder(1, 1)
+        make_action_state = MakeActionState(places)
+        self.assertEqual(HasAction.AUTOMATIC_ACTION_DONE,
+                         make_action_state.try_to_make_automatic_action(player))
+
+    def test_try_automatic_action_mix(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.FIELD: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.BUILDING_TILE1: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+            Location.QUARY: LocationMock(try_response=HasAction.AUTOMATIC_ACTION_DONE),
+            Location.BUILDING_TILE2: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+            Location.FOREST: LocationMock(try_response=HasAction.AUTOMATIC_ACTION_DONE),
+            Location.HUNTING_GROUNDS: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+        }
+        player = PlayerOrder(1, 1)
+        make_action_state = MakeActionState(places)
+        self.assertEqual(HasAction.AUTOMATIC_ACTION_DONE,
+                         make_action_state.try_to_make_automatic_action(player))

--- a/test/game_phase_controller/test_make_action_state.py
+++ b/test/game_phase_controller/test_make_action_state.py
@@ -118,3 +118,14 @@ class TestMakeActionState(unittest.TestCase):
         make_action_state = MakeActionState(places)
         self.assertEqual(HasAction.AUTOMATIC_ACTION_DONE,
                          make_action_state.try_to_make_automatic_action(player))
+
+    def test_wrong_method_called(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.FIELD: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.QUARY: LocationMock(try_response=HasAction.AUTOMATIC_ACTION_DONE),
+        }
+        player = PlayerOrder(1, 1)
+        make_action_state = MakeActionState(places)
+        self.assertEqual(ActionResult.FAILURE,
+                         make_action_state.no_more_tools_this_throw(player))

--- a/test/game_phase_controller/test_new_round_state.py
+++ b/test/game_phase_controller/test_new_round_state.py
@@ -21,7 +21,7 @@ class NewTurnFake(InterfaceNewTurn):
         pass
 
 
-class TestMakeActionState(unittest.TestCase):
+class TestNewRoundState(unittest.TestCase):
     def test_no_game_end(self) -> None:
         places: Mapping[Location, LocationMock] = {
             Location.HUT: LocationMock(False),

--- a/test/game_phase_controller/test_new_round_state.py
+++ b/test/game_phase_controller/test_new_round_state.py
@@ -3,7 +3,7 @@ from typing import Mapping
 
 from stone_age.game_phase_controller.new_round_state import NewRoundState
 from stone_age.interfaces import InterfaceFigureLocation, InterfaceNewTurn
-from stone_age.simple_types import PlayerOrder, HasAction, Location
+from stone_age.simple_types import PlayerOrder, HasAction, Location, ActionResult
 
 
 class LocationMock(InterfaceFigureLocation):
@@ -43,3 +43,13 @@ class TestMakeActionState(unittest.TestCase):
         player = PlayerOrder(1, 1)
         self.assertEqual(HasAction.NO_ACTION_POSSIBLE,
                          new_round_state.try_to_make_automatic_action(player))
+
+    def test_failure_method(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(False),
+            Location.CIVILISATION_CARD1: LocationMock(True),
+        }
+        new_round_state = NewRoundState(places, NewTurnFake())
+        player = PlayerOrder(1, 1)
+        self.assertEqual(ActionResult.FAILURE,
+                         new_round_state.do_not_feed_this_turn(player))

--- a/test/game_phase_controller/test_new_round_state.py
+++ b/test/game_phase_controller/test_new_round_state.py
@@ -1,0 +1,45 @@
+import unittest
+from typing import Mapping
+
+from stone_age.game_phase_controller.new_round_state import NewRoundState
+from stone_age.interfaces import InterfaceFigureLocation, InterfaceNewTurn
+from stone_age.simple_types import PlayerOrder, HasAction, Location
+
+
+class LocationMock(InterfaceFigureLocation):
+    _new_turn_response: bool
+
+    def __init__(self, new_turn_response: bool):
+        self._new_turn_response = new_turn_response
+
+    def new_turn(self) -> bool:
+        return self._new_turn_response
+
+
+class NewTurnFake(InterfaceNewTurn):
+    def new_turn(self) -> None:
+        pass
+
+
+class TestMakeActionState(unittest.TestCase):
+    def test_no_game_end(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(False),
+            Location.CIVILISATION_CARD1: LocationMock(False),
+            Location.FIELD: LocationMock(False)
+        }
+        new_round_state = NewRoundState(places, NewTurnFake())
+        player = PlayerOrder(1, 1)
+        self.assertEqual(HasAction.AUTOMATIC_ACTION_DONE,
+                         new_round_state.try_to_make_automatic_action(player))
+
+    def test_game_end(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(False),
+            Location.CIVILISATION_CARD1: LocationMock(True),
+            Location.FIELD: LocationMock(False)
+        }
+        new_round_state = NewRoundState(places, NewTurnFake())
+        player = PlayerOrder(1, 1)
+        self.assertEqual(HasAction.NO_ACTION_POSSIBLE,
+                         new_round_state.try_to_make_automatic_action(player))

--- a/test/game_phase_controller/test_place_figures_state.py
+++ b/test/game_phase_controller/test_place_figures_state.py
@@ -62,7 +62,8 @@ class TestPlaceFiguresState(unittest.TestCase):
             Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
             Location.QUARY: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
             Location.CIVILISATION_CARD1: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
-            Location.BUILDING_TILE1: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE)
+            Location.BUILDING_TILE1: LocationMock(
+                try_response=HasAction.NO_ACTION_POSSIBLE)
         }
         player = PlayerOrder(1, 1)
         place_figures_state = PlaceFiguresState(places)
@@ -74,7 +75,8 @@ class TestPlaceFiguresState(unittest.TestCase):
             Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
             Location.QUARY: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
             Location.CIVILISATION_CARD1: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
-            Location.BUILDING_TILE1: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE)
+            Location.BUILDING_TILE1: LocationMock(
+                try_response=HasAction.NO_ACTION_POSSIBLE)
         }
         player = PlayerOrder(1, 1)
         place_figures_state = PlaceFiguresState(places)
@@ -85,8 +87,10 @@ class TestPlaceFiguresState(unittest.TestCase):
         places = {
             Location.HUT: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
             Location.QUARY: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
-            Location.CIVILISATION_CARD1: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
-            Location.BUILDING_TILE1: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION)
+            Location.CIVILISATION_CARD1: LocationMock(
+                try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+            Location.BUILDING_TILE1: LocationMock(
+                try_response=HasAction.WAITING_FOR_PLAYER_ACTION)
         }
         player = PlayerOrder(1, 1)
         place_figures_state = PlaceFiguresState(places)

--- a/test/game_phase_controller/test_place_figures_state.py
+++ b/test/game_phase_controller/test_place_figures_state.py
@@ -1,0 +1,94 @@
+import unittest
+from typing import Iterable, Mapping
+
+from stone_age.game_phase_controller.place_figures_state import PlaceFiguresState
+from stone_age.interfaces import InterfaceFigureLocation
+from stone_age.simple_types import PlayerOrder, HasAction, Effect, ActionResult, Location
+
+
+class LocationMock(InterfaceFigureLocation):
+    _place_response: bool
+    _try_response: HasAction
+
+    def __init__(self, place_response: bool = False,
+                 try_response: HasAction = HasAction.NO_ACTION_POSSIBLE):
+        self._place_response = place_response
+        self._try_response = try_response
+
+    def place_figures(self, player: PlayerOrder, figure_count: int) -> bool:
+        return self._place_response
+
+    def try_to_place_figures(self, player: PlayerOrder, count: int) -> HasAction:
+        return self._try_response
+
+    def make_action(self, player: PlayerOrder, input_resources: Iterable[Effect],
+                    output_resources: Iterable[Effect]) -> ActionResult:
+        assert False
+
+    def skip_action(self, player: PlayerOrder) -> bool:
+        assert False
+
+    def try_to_make_action(self, player: PlayerOrder) -> HasAction:
+        assert False
+
+    def new_turn(self) -> bool:
+        assert False
+
+
+class TestPlaceFiguresState(unittest.TestCase):
+    def test_place_figures_method(self) -> None:
+        places: Mapping[Location, LocationMock] = {
+            Location.HUT: LocationMock(True),
+            Location.FIELD: LocationMock(False),
+        }
+        player = PlayerOrder(1, 1)
+        place_figures_state = PlaceFiguresState(places)
+        self.assertEqual(ActionResult.ACTION_DONE,
+                         place_figures_state.place_figures(player, Location.HUT, 1))
+        self.assertEqual(ActionResult.FAILURE,
+                         place_figures_state.place_figures(player, Location.FIELD, 1))
+
+    def test_try_automatic_action_one_location(self) -> None:
+        places = {
+            Location.HUT: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+        }
+        player = PlayerOrder(1, 1)
+        place_figures_state = PlaceFiguresState(places)
+        self.assertEqual(HasAction.WAITING_FOR_PLAYER_ACTION,
+                         place_figures_state.try_to_make_automatic_action(player))
+
+    def test_try_automatic_action_no_good_location(self) -> None:
+        places = {
+            Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.QUARY: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.CIVILISATION_CARD1: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.BUILDING_TILE1: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE)
+        }
+        player = PlayerOrder(1, 1)
+        place_figures_state = PlaceFiguresState(places)
+        self.assertEqual(HasAction.NO_ACTION_POSSIBLE,
+                         place_figures_state.try_to_make_automatic_action(player))
+
+    def test_try_automatic_action_one_good_location(self) -> None:
+        places = {
+            Location.HUT: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.QUARY: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+            Location.CIVILISATION_CARD1: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE),
+            Location.BUILDING_TILE1: LocationMock(try_response=HasAction.NO_ACTION_POSSIBLE)
+        }
+        player = PlayerOrder(1, 1)
+        place_figures_state = PlaceFiguresState(places)
+        self.assertEqual(HasAction.WAITING_FOR_PLAYER_ACTION,
+                         place_figures_state.try_to_make_automatic_action(player))
+
+    def test_try_automatic_action_all_good_locations(self) -> None:
+        places = {
+            Location.HUT: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+            Location.QUARY: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+            Location.CIVILISATION_CARD1: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION),
+            Location.BUILDING_TILE1: LocationMock(try_response=HasAction.WAITING_FOR_PLAYER_ACTION)
+        }
+        player = PlayerOrder(1, 1)
+        place_figures_state = PlaceFiguresState(places)
+        self.assertEqual(HasAction.WAITING_FOR_PLAYER_ACTION,
+                         place_figures_state.try_to_make_automatic_action(player))


### PR DESCRIPTION
Implemented PlaceFiguresState, MakeActionState, NewRoundState and GameEndState with their unittests.

They do some non-trivial operations mainly in try_to_make_automatic_action methods, which rely heavily on implementation of InterfaceFigureLocation, more info in docstrings for these functions or in note on the right side of design UML diagram.

Also added one metaclass GamePhaseStateFailureMeta(InterfaceGamePhaseState). This class contains all methods from InterfaceGamePhaseState, those with return type ActionResult return ActionResult.FAILURE. State/Phase classes inherit from this class instead to prevent code duplicity. 
This design allows us to have default responses for method calls in wrong phase (e. g. MakeActionState.place_figures(...) will allways return ActionResult.FAILURE, it does not make sense to place additional figures in MakeActionState phase of game).