### PR TITLE
PlayerTools fix

### DIFF
--- a/stone_age/player_board/player_tools.py
+++ b/stone_age/player_board/player_tools.py
@@ -14,10 +14,10 @@ class PlayerTools(InterfaceGetState):
         self._used_tools = [False for _ in range(3)]
 
     def add_tool(self) -> None:
-        minimal_tool: int = min(self._tools)
+        minimal_tool: int = min(self._tools[:3])
         minimal_tool_index: int = self._tools.index(minimal_tool)
 
-        if minimal_tool < 4 and minimal_tool_index < 3:
+        if minimal_tool < 4:
             self._tools[minimal_tool_index] += 1
 
     def add_single_use_tool(self, strength: int) -> None:

--- a/stone_age/player_board/player_tools.py
+++ b/stone_age/player_board/player_tools.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+import json
+
+from typing import List, Optional, Any
 from stone_age.interfaces import InterfaceGetState
 
 
@@ -9,7 +11,7 @@ class PlayerTools(InterfaceGetState):
         self._used_tools: List[bool] = [False] * 3
 
     def new_turn(self) -> None:
-        self._used_tools = [False for _ in range(len(self._tools))]
+        self._used_tools = [False for _ in range(3)]
 
     def add_tool(self) -> None:
         minimal_tool: int = min(self._tools)
@@ -21,20 +23,19 @@ class PlayerTools(InterfaceGetState):
     def add_single_use_tool(self, strength: int) -> None:
         if 2 <= strength <= 4:
             self._tools.append(strength)
-            self._used_tools.append(False)
 
     def use_tool(self, index: int) -> Optional[int]:
         if index < 0 or index >= len(self._tools):
             return None
 
         element: int = self._tools[index]
-        if self._used_tools[index] or element == 0:
+        if (index < 3 and self._used_tools[index]) or element == 0:
             return None
 
         if index < 3:
             self._used_tools[index] = True
         else:
-            del self._used_tools[index], self._tools[index]
+            del self._tools[index]
 
         return element
 
@@ -42,7 +43,7 @@ class PlayerTools(InterfaceGetState):
         strength_sum: int = 0
 
         for index, tool in enumerate(self._tools):
-            if not self._used_tools[index]:
+            if index >= 3 or not self._used_tools[index]:
                 strength_sum += tool
 
         return strength_sum >= goal
@@ -52,6 +53,9 @@ class PlayerTools(InterfaceGetState):
         return len(self._tools)
 
     def state(self) -> str:
-        return '\n'.join([f"{'Single-use tool: ' if index >= 3 else f'Tool {index + 1}: '}"
-                          f"{strength}, {'used' if self._used_tools[index] else 'unused'}"
-                          for index, strength in enumerate(self._tools) if strength != 0])
+        state: Any = {
+            "tools strength": self._tools[:3],
+            "used tools": self._used_tools,
+            "single-use tools": self._tools[3:]
+        }
+        return json.dumps(state)

--- a/test/player_board/test_player_tools.py
+++ b/test/player_board/test_player_tools.py
@@ -1,4 +1,7 @@
 import unittest
+import json
+
+from typing import Any
 from stone_age.player_board.player_tools import PlayerTools
 
 
@@ -10,28 +13,37 @@ class TestPlayerTools(unittest.TestCase):
         p1.add_tool()
         p1.add_tool()
 
-        self.assertIn("Tool 1: 1, unused\nTool 2: 1, unused", p1.state())
+        state_start: Any = json.loads(p1.state())
+        self.assertEqual(state_start, {"tools strength": [1, 1, 0],
+                                       "used tools": [False, False, False],
+                                       "single-use tools": []})
         self.assertFalse(p1.has_sufficient_tools(11))
 
         for _ in range(4):
             p1.add_tool()
 
-        self.assertIn(
-            "Tool 1: 2, unused\nTool 2: 2, unused\nTool 3: 2, unused", p1.state())
+        state_after_adding1: Any = json.loads(p1.state())
+        self.assertEqual(state_after_adding1, {"tools strength": [2, 2, 2],
+                                               "used tools": [False, False, False],
+                                               "single-use tools": []})
         self.assertFalse(p1.has_sufficient_tools(11))
 
         for _ in range(4):
             p1.add_tool()
 
-        self.assertIn(
-            "Tool 1: 4, unused\nTool 2: 3, unused\nTool 3: 3, unused", p1.state())
+        state_after_adding2: Any = json.loads(p1.state())
+        self.assertEqual(state_after_adding2, {"tools strength": [4, 3, 3],
+                                               "used tools": [False, False, False],
+                                               "single-use tools": []})
         self.assertFalse(p1.has_sufficient_tools(11))
 
         for _ in range(3):
             p1.add_tool()
 
-        self.assertIn(
-            "Tool 1: 4, unused\nTool 2: 4, unused\nTool 3: 4, unused", p1.state())
+        state_after_adding3: Any = json.loads(p1.state())
+        self.assertEqual(state_after_adding3, {"tools strength": [4, 4, 4],
+                                               "used tools": [False, False, False],
+                                               "single-use tools": []})
         self.assertTrue(p1.has_sufficient_tools(11))
 
     def test_figures_taking(self) -> None:
@@ -43,15 +55,21 @@ class TestPlayerTools(unittest.TestCase):
         self.assertTrue(p1.has_sufficient_tools(7))
         p1.use_tool(0)
         self.assertFalse(p1.has_sufficient_tools(7))
-        self.assertIn(
-            "Tool 1: 4, used\nTool 2: 3, unused\nTool 3: 3, unused", p1.state())
+        state_after_use1: Any = json.loads(p1.state())
+        self.assertEqual(state_after_use1, {"tools strength": [4, 3, 3],
+                                            "used tools": [True, False, False],
+                                            "single-use tools": []})
         p1.use_tool(1)
         p1.use_tool(2)
-        self.assertIn(
-            "Tool 1: 4, used\nTool 2: 3, used\nTool 3: 3, used", p1.state())
+        state_after_use2: Any = json.loads(p1.state())
+        self.assertEqual(state_after_use2, {"tools strength": [4, 3, 3],
+                                            "used tools": [True, True, True],
+                                            "single-use tools": []})
         p1.add_tool()
-        self.assertIn(
-            "Tool 1: 4, used\nTool 2: 4, used\nTool 3: 3, used", p1.state())
+        state_after_add: Any = json.loads(p1.state())
+        self.assertEqual(state_after_add, {"tools strength": [4, 4, 3],
+                                           "used tools": [True, True, True],
+                                           "single-use tools": []})
         self.assertFalse(p1.has_sufficient_tools(4))
 
     def test_new_turn(self) -> None:
@@ -62,40 +80,60 @@ class TestPlayerTools(unittest.TestCase):
 
         p1.use_tool(0)
         p1.use_tool(1)
-        self.assertIn(
-            "Tool 1: 4, used\nTool 2: 3, used\nTool 3: 3, unused", p1.state())
+
+        state_after_use: Any = json.loads(p1.state())
+        self.assertEqual(state_after_use, {"tools strength": [4, 3, 3],
+                                           "used tools": [True, True, False],
+                                           "single-use tools": []})
         p1.new_turn()
-        self.assertIn(
-            "Tool 1: 4, unused\nTool 2: 3, unused\nTool 3: 3, unused", p1.state())
+        state_new_turn: Any = json.loads(p1.state())
+        self.assertEqual(state_new_turn, {"tools strength": [4, 3, 3],
+                                          "used tools": [False, False, False],
+                                          "single-use tools": []})
 
     def test_single_use_tool(self) -> None:
         p1 = PlayerTools()
 
         p1.add_single_use_tool(3)
-        self.assertIn("Single-use tool: 3, unused", p1.state())
+        state_single_use1: Any = json.loads(p1.state())
+        self.assertEqual(state_single_use1, {"tools strength": [0, 0, 0],
+                                             "used tools": [False, False, False],
+                                             "single-use tools": [3]})
         p1.add_tool()
         p1.add_tool()
-        self.assertIn("Tool 1: 1, unused\nTool 2: 1, unused\n"
-                      "Single-use tool: 3, unused", p1.state())
+        state_add_tools1: Any = json.loads(p1.state())
+        self.assertEqual(state_add_tools1, {"tools strength": [1, 1, 0],
+                                            "used tools": [False, False, False],
+                                            "single-use tools": [3]})
         p1.add_single_use_tool(2)
-        self.assertIn("Tool 1: 1, unused\nTool 2: 1, unused\n"
-                      "Single-use tool: 3, unused\nSingle-use tool: 2, unused", p1.state())
+        state_single_use2: Any = json.loads(p1.state())
+        self.assertEqual(state_single_use2, {"tools strength": [1, 1, 0],
+                                             "used tools": [False, False, False],
+                                             "single-use tools": [3, 2]})
         self.assertTrue(p1.has_sufficient_tools(5))
         p1.use_tool(3)
-        self.assertIn("Tool 1: 1, unused\nTool 2: 1, unused\n"
-                      "Single-use tool: 2, unused", p1.state())
+        state_after_use: Any = json.loads(p1.state())
+        self.assertEqual(state_after_use, {"tools strength": [1, 1, 0],
+                                           "used tools": [False, False, False],
+                                           "single-use tools": [2]})
         self.assertFalse(p1.has_sufficient_tools(5))
         p1.add_tool()
-        self.assertIn("Tool 1: 1, unused\nTool 2: 1, unused\n"
-                      "Tool 3: 1, unused\nSingle-use tool: 2, unused", p1.state())
+        state_add_tools2: Any = json.loads(p1.state())
+        self.assertEqual(state_add_tools2, {"tools strength": [1, 1, 1],
+                                            "used tools": [False, False, False],
+                                            "single-use tools": [2]})
         p1.new_turn()
-        self.assertIn("Tool 1: 1, unused\nTool 2: 1, unused\n"
-                      "Tool 3: 1, unused\nSingle-use tool: 2, unused", p1.state())
+        state_new_turn: Any = json.loads(p1.state())
+        self.assertEqual(state_new_turn, {"tools strength": [1, 1, 1],
+                                          "used tools": [False, False, False],
+                                          "single-use tools": [2]})
         p1.add_single_use_tool(1)
         p1.add_single_use_tool(5)
         p1.add_single_use_tool(-1)
-        self.assertIn("Tool 1: 1, unused\nTool 2: 1, unused\n"
-                      "Tool 3: 1, unused\nSingle-use tool: 2, unused", p1.state())
+        state_single_use3: Any = json.loads(p1.state())
+        self.assertEqual(state_single_use3, {"tools strength": [1, 1, 1],
+                                             "used tools": [False, False, False],
+                                             "single-use tools": [2]})
 
     def test_add_too_much(self) -> None:
         p1 = PlayerTools()
@@ -103,24 +141,36 @@ class TestPlayerTools(unittest.TestCase):
         for _ in range(100):
             p1.add_tool()
 
-        self.assertIn(
-            "Tool 1: 4, unused\nTool 2: 4, unused\nTool 3: 4, unused", p1.state())
+        state_add_too_much: Any = json.loads(p1.state())
+        self.assertEqual(state_add_too_much, {"tools strength": [4, 4, 4],
+                                              "used tools": [False, False, False],
+                                              "single-use tools": []})
         p1.add_single_use_tool(2)
         p1.add_single_use_tool(3)
         p1.add_single_use_tool(4)
-        self.assertIn("Tool 1: 4, unused\nTool 2: 4, unused\nTool 3: 4, unused\n"
-                      "Single-use tool: 2, unused\nSingle-use tool: 3, unused\n"
-                      "Single-use tool: 4, unused", p1.state())
+        state_add_singles1: Any = json.loads(p1.state())
+        self.assertEqual(state_add_singles1, {"tools strength": [4, 4, 4],
+                                              "used tools": [False, False, False],
+                                              "single-use tools": [2, 3, 4]})
         p1.add_tool()
         p1.add_tool()
         p1.add_single_use_tool(2)
-        self.assertIn("Tool 1: 4, unused\nTool 2: 4, unused\nTool 3: 4, unused\n"
-                      "Single-use tool: 2, unused\nSingle-use tool: 3, unused\n"
-                      "Single-use tool: 4, unused\nSingle-use tool: 2, unused", p1.state())
+        state_add_singles2: Any = json.loads(p1.state())
+        self.assertEqual(state_add_singles2, {"tools strength": [4, 4, 4],
+                                              "used tools": [False, False, False],
+                                              "single-use tools": [2, 3, 4, 2]})
         p1.use_tool(4)
         p1.use_tool(5)
-        self.assertIn("Tool 1: 4, unused\nTool 2: 4, unused\nTool 3: 4, unused\n"
-                      "Single-use tool: 2, unused\nSingle-use tool: 4, unused", p1.state())
+        state_after_use1: Any = json.loads(p1.state())
+        self.assertEqual(state_after_use1, {"tools strength": [4, 4, 4],
+                                            "used tools": [False, False, False],
+                                            "single-use tools": [2, 4]})
+        p1.use_tool(3)
+        p1.use_tool(3)
+        state_after_use2: Any = json.loads(p1.state())
+        self.assertEqual(state_after_use2, {"tools strength": [4, 4, 4],
+                                            "used tools": [False, False, False],
+                                            "single-use tools": []})
 
     def test_use_tools(self) -> None:
         p1 = PlayerTools()
@@ -163,6 +213,28 @@ class TestPlayerTools(unittest.TestCase):
         self.assertFalse(p1.has_sufficient_tools(12))
         p1.new_turn()
         self.assertTrue(p1.has_sufficient_tools(12))
+
+    def test_use_two_times(self):
+        p1 = PlayerTools()
+
+        for _ in range(12):
+            p1.add_tool()
+
+        p1.use_tool(0)
+        p1.use_tool(1)
+        p1.use_tool(2)
+
+        state_after_use1: Any = json.loads(p1.state())
+        self.assertEqual(state_after_use1, {"tools strength": [4, 4, 4],
+                                            "used tools": [True, True, True],
+                                            "single-use tools": []})
+
+        self.assertEqual(None, p1.use_tool(1))
+        p1.new_turn()
+        self.assertEqual(4, p1.use_tool(1))
+        p1.add_single_use_tool(2)
+        self.assertEqual(2, p1.use_tool(3))
+        self.assertEqual(None, p1.use_tool(3))
 
 
 if __name__ == '__main__':

--- a/test/player_board/test_player_tools.py
+++ b/test/player_board/test_player_tools.py
@@ -236,6 +236,18 @@ class TestPlayerTools(unittest.TestCase):
         self.assertEqual(2, p1.use_tool(3))
         self.assertEqual(None, p1.use_tool(3))
 
+    def test_after_review(self) -> None:
+        p1 = PlayerTools()
+        for _ in range(9):
+            p1.add_tool()
+        s1: Any = json.loads(p1.state())
+        self.assertEqual(s1["tools strength"], [3, 3, 3])
+
+        p1.add_single_use_tool(2)
+        p1.add_tool()
+        s2: Any = json.loads(p1.state())
+        self.assertEqual(s2["tools strength"], [4, 3, 3])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/player_board/test_player_tools.py
+++ b/test/player_board/test_player_tools.py
@@ -214,7 +214,7 @@ class TestPlayerTools(unittest.TestCase):
         p1.new_turn()
         self.assertTrue(p1.has_sufficient_tools(12))
 
-    def test_use_two_times(self):
+    def test_use_two_times(self) -> None:
         p1 = PlayerTools()
 
         for _ in range(12):


### PR DESCRIPTION
Amended the PlayerTools class:
- state method is implemented with jsons instead of usual strings
- used_tools list is limited to 3 elements (we don`t need False values for single-use tools)

The unit tests were changed accordingly to the changes in the class + one new unit test was added