### PR TITLE
Fix InterfaceGetState

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -37,10 +37,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -56,10 +56,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Tests
       run: |
         python3 -m unittest 

--- a/stone_age/interfaces.py
+++ b/stone_age/interfaces.py
@@ -37,7 +37,7 @@ class InterfaceGamePhaseController:
 
 
 class InterfaceGetState:
-    def get_state(self) -> str:
+    def state(self) -> str:
         assert False
 
 

--- a/stone_age/player_board/player_board.py
+++ b/stone_age/player_board/player_board.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 import json
 from stone_age.interfaces import InterfaceGetState
 from stone_age.player_board.player_civilisation_cards import PlayerCivilisationCards
@@ -65,6 +65,7 @@ class PlayerBoard(InterfaceGetState):
             self._figures.get_total_figures
         )
 
+    @override
     def state(self) -> str:
         state: Any = {
             "points": self._points,

--- a/stone_age/player_board/player_civilisation_cards.py
+++ b/stone_age/player_board/player_civilisation_cards.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Any
+from typing import Dict, List, Any, override
 from collections import defaultdict
 import json
 
@@ -55,6 +55,7 @@ class PlayerCivilisationCards(InterfaceGetState):
 
         return result_points
 
+    @override
     def state(self) -> str:
         state: Any = {
             entry.name: self._end_effect_cards.get(entry, 0)

--- a/stone_age/player_board/player_resources_and_food.py
+++ b/stone_age/player_board/player_resources_and_food.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any
+from typing import Any, override
 import json
 
 from stone_age.interfaces import InterfaceGetState
@@ -39,6 +39,7 @@ class PlayerResourcesAndFood(InterfaceGetState):
         return sum(Effect.points(resource) * count
                    for resource, count in self._resources.items())
 
+    @override
     def state(self) -> str:
         state: Any = {
             entry.name: self._resources.get(entry, 0)

--- a/stone_age/player_board/player_tools.py
+++ b/stone_age/player_board/player_tools.py
@@ -1,6 +1,6 @@
 import json
 
-from typing import List, Optional, Any
+from typing import List, Optional, Any, override
 from stone_age.interfaces import InterfaceGetState
 
 
@@ -52,6 +52,7 @@ class PlayerTools(InterfaceGetState):
     def tool_count(self) -> int:
         return len(self._tools)
 
+    @override
     def state(self) -> str:
         state: Any = {
             "tools strength": self._tools[:3],

--- a/stone_age/player_board/tribe_fed_status.py
+++ b/stone_age/player_board/tribe_fed_status.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import List, Any, override
 import json
 
 from stone_age.interfaces import InterfaceGetState
@@ -98,6 +98,7 @@ class TribeFedStatus(InterfaceGetState):
     def fields(self) -> int:
         return self._fields
 
+    @override
     def state(self) -> str:
         state: Any = {
             "tribe fed": self._tribe_fed,

--- a/stone_age/stone_age_game.py
+++ b/stone_age/stone_age_game.py
@@ -45,11 +45,11 @@ class StoneAgeGame(InterfaceStoneAgeGame):
         """
         self._state = json.dumps({
             "player_board " + str(self._players[i]):
-                json.loads(self._player_boards[self._players[i]].get_state())
+                json.loads(self._player_boards[self._players[i]].state())
                 for i in sorted(self._players)
-            } | {"game_board": json.loads(self._game_board.get_state()),
-                 "game_phase": json.loads(self._phase_controller.state())}
-            )
+        } | {"game_board": json.loads(self._game_board.state()),
+             "game_phase": json.loads(self._phase_controller.state())}
+        )
 
     def place_figures(self, player_id: int, location: Location, figures_count: int) -> bool:
         output: bool = self._phase_controller.place_figures(self._players[player_id],
@@ -67,31 +67,36 @@ class StoneAgeGame(InterfaceStoneAgeGame):
         return output
 
     def skip_action(self, player_id: int, location: Location) -> bool:
-        output: bool = self._phase_controller.skip_action(self._players[player_id], location)
+        output: bool = self._phase_controller.skip_action(
+            self._players[player_id], location)
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def use_tools(self, player_id: int, tool_index: int) -> bool:
-        output: bool = self._phase_controller.use_tools(self._players[player_id], tool_index)
+        output: bool = self._phase_controller.use_tools(
+            self._players[player_id], tool_index)
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def no_more_tools_this_throw(self, player_id: int) -> bool:
-        output: bool = self._phase_controller.no_more_tools_this_throw(self._players[player_id])
+        output: bool = self._phase_controller.no_more_tools_this_throw(
+            self._players[player_id])
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def feed_tribe(self, player_id: int, resources: Iterable[Effect]) -> bool:
-        output: bool = self._phase_controller.feed_tribe(self._players[player_id], resources)
+        output: bool = self._phase_controller.feed_tribe(
+            self._players[player_id], resources)
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def do_not_feed_this_turn(self, player_id: int) -> bool:
-        output: bool = self._phase_controller.do_not_feed_this_turn(self._players[player_id])
+        output: bool = self._phase_controller.do_not_feed_this_turn(
+            self._players[player_id])
         self._update_state()
         self._observable.notify(self._state)
         return output

--- a/stone_age/stone_age_game.py
+++ b/stone_age/stone_age_game.py
@@ -25,12 +25,14 @@ class StoneAgeGame(InterfaceStoneAgeGame):
     _phase_controller: InterfaceGamePhaseController
     _observable: StoneAgeObservable
 
-    def __init__(self, players: Mapping[int, PlayerOrder],
-                 player_boards: Mapping[PlayerOrder, InterfaceGetState],
-                 game_board: InterfaceGetState,
-                 phase_controller: InterfaceGamePhaseController,
-                 observable: StoneAgeObservable
-                 ) -> None:
+    def __init__(
+        self,
+        players: Mapping[int, PlayerOrder],
+        player_boards: Mapping[PlayerOrder, InterfaceGetState],
+        game_board: InterfaceGetState,
+        phase_controller: InterfaceGamePhaseController,
+        observable: StoneAgeObservable
+    ) -> None:
         self._players = players
         self._player_boards = player_boards
         self._game_board = game_board
@@ -46,64 +48,87 @@ class StoneAgeGame(InterfaceStoneAgeGame):
         self._state = json.dumps({
             "player_board " + str(self._players[i]):
                 json.loads(self._player_boards[self._players[i]].state())
-                for i in sorted(self._players)
-        } | {"game_board": json.loads(self._game_board.state()),
-             "game_phase": json.loads(self._phase_controller.state())}
-        )
+            for i in sorted(self._players)
+        } | {
+            "game_board": json.loads(self._game_board.state()),
+            "game_phase": json.loads(self._phase_controller.state())
+        })
 
     def place_figures(self, player_id: int, location: Location, figures_count: int) -> bool:
-        output: bool = self._phase_controller.place_figures(self._players[player_id],
-                                                            location, figures_count)
+        output: bool = self._phase_controller.place_figures(
+            self._players[player_id],
+            location,
+            figures_count
+        )
         self._update_state()
         self._observable.notify(self._state)
         return output
 
-    def make_action(self, player_id: int, location: Location,
-                    used_resources: Iterable[Effect], desired_resource: Iterable[Effect]) -> bool:
-        output: bool = self._phase_controller.make_action(self._players[player_id], location,
-                                                          used_resources, desired_resource)
+    def make_action(
+        self,
+        player_id: int,
+        location: Location,
+        used_resources: Iterable[Effect],
+        desired_resource: Iterable[Effect]
+    ) -> bool:
+        output: bool = self._phase_controller.make_action(
+            self._players[player_id],
+            location,
+            used_resources,
+            desired_resource
+        )
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def skip_action(self, player_id: int, location: Location) -> bool:
         output: bool = self._phase_controller.skip_action(
-            self._players[player_id], location)
+            self._players[player_id],
+            location
+        )
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def use_tools(self, player_id: int, tool_index: int) -> bool:
         output: bool = self._phase_controller.use_tools(
-            self._players[player_id], tool_index)
+            self._players[player_id],
+            tool_index
+        )
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def no_more_tools_this_throw(self, player_id: int) -> bool:
         output: bool = self._phase_controller.no_more_tools_this_throw(
-            self._players[player_id])
+            self._players[player_id]
+        )
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def feed_tribe(self, player_id: int, resources: Iterable[Effect]) -> bool:
         output: bool = self._phase_controller.feed_tribe(
-            self._players[player_id], resources)
+            self._players[player_id],
+            resources
+        )
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def do_not_feed_this_turn(self, player_id: int) -> bool:
         output: bool = self._phase_controller.do_not_feed_this_turn(
-            self._players[player_id])
+            self._players[player_id]
+        )
         self._update_state()
         self._observable.notify(self._state)
         return output
 
     def make_all_players_take_a_reward_choice(self, player_id: int, reward: Effect) -> bool:
         output: bool = self._phase_controller.make_all_players_take_a_reward_choice(
-            self._players[player_id], reward)
+            self._players[player_id],
+            reward
+        )
         self._update_state()
         self._observable.notify(self._state)
         return output


### PR DESCRIPTION
Rename `InterfaceGetState.get_state()` to `InterfaceGetState.state()`.

Notes:
It worked previously because our setup doesn't check if a class implements all functions from inherited interfaces. Instead, it only checks functions declared in inherited interfaces. With `@override`, however, it will also be checked if a marked function actually overrides a method from one of the inherited interfaces.